### PR TITLE
Bump cosign version

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,7 +59,7 @@ jobs:
               if: github.event_name != 'pull_request'
               uses: sigstore/cosign-installer@6e04d228eb30da1757ee4e1dd75a0ec73a653e06 #v3.1.1
               with:
-                  cosign-release: 'v2.1.1'
+                  cosign-release: 'v2.2.4'
 
             # Set up BuildKit Docker container builder to be able to build
             # multi-platform images and export cache


### PR DESCRIPTION
The older version of cosign broke recently, resulting in our docker workflow failing